### PR TITLE
Fixed `TypeError: check_type() takes 2 positional arguments but 3 were given` with typeguard 3.0.0+

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.7.1 - Compatibility fix for typeguard `3.0.0`
+
+ - Fixed `TypeError: check_type() takes 2 positional arguments but 3 were given` triggering erroneous `FieldTypeError` 
+   when `typeguard>=3.0.0` is used. Fixed [#87](https://github.com/smarie/python-pyfields/issues/87)
+
 ### 1.7.0 - Better support for non-deep-copiable default values in `@autofields`
 
  - `@autofields` and `@autoclass` now raise an error when a field definition can not be valid, because the default value can not be deep-copied. This will help users detect issues such as [#84](https://github.com/smarie/python-pyfields/issues/84) earlier. Implementation is done through a new `autocheck` option in the `copy_value` factory.

--- a/pyfields/typing_utils.py
+++ b/pyfields/typing_utils.py
@@ -4,6 +4,8 @@
 # License: 3-clause BSD, <https://github.com/smarie/python-pyfields/blob/master/LICENSE>
 import sys
 
+from pkg_resources import get_distribution
+
 
 class FieldTypeError(TypeError):  # FieldError
     """
@@ -45,7 +47,19 @@ class FieldTypeError(TypeError):  # FieldError
 
 def _make_assert_is_of_type():
     try:
-        from typeguard import check_type
+        from typeguard import check_type as ct
+        from packaging.version import parse as parse_version
+
+        # Note: only do this when we are sure that typeguard can be imported, otherwise this is slow
+        # see https://github.com/smarie/python-getversion/blob/ee495acf6cf06c5e860713edeee396206368e458/getversion/main.py#L84
+        typeguard_version = get_distribution("typeguard").version
+        if parse_version(typeguard_version) < parse_version("3.0.0"):
+            check_type = ct
+        else:
+            # Name has disappeared from 3.0.0
+            def check_type(name, value, typ):
+                ct(value, typ)
+
         try:
             from typing import Union
         except ImportError:


### PR DESCRIPTION
Fixed `TypeError: check_type() takes 2 positional arguments but 3 were given` triggering erroneous `FieldTypeError` when `typeguard>=3.0.0` is used. Fixed #87